### PR TITLE
brazil-county-1 - Criando tabela, estrutura de classes, data patch para popular e query com todos os filtros possiveis

### DIFF
--- a/Api/Data/BrazilCountyInterface.php
+++ b/Api/Data/BrazilCountyInterface.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace TheITNerd\Brasil\Api\Data;
 
 /**
- * Interface for brazil_county table data model
+ * Interface BrazilCountyInterface
+ * @package TheITNerd\Brasil\Api\Data
  */
 interface BrazilCountyInterface
 {

--- a/Api/Data/BrazilCountyInterface.php
+++ b/Api/Data/BrazilCountyInterface.php
@@ -1,0 +1,309 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Api\Data;
+
+/**
+ * Interface for brazil_county table data model
+ */
+interface BrazilCountyInterface
+{
+    /** @var string TABLE */
+    public const TABLE = 'brazil_county';
+
+    /** @var string ENTITY_ID */
+    public const ENTITY_ID = 'entity_id';
+
+    /** @var string COUNTY_ID */
+    public const COUNTY_ID = 'county_id';
+
+    /** @var string COUNTY_NAME */
+    public const COUNTY_NAME = 'county_name';
+
+    /** @var string MICROREGION_ID */
+    public const MICROREGION_ID = 'microregion_id';
+
+    /** @var string MICROREGION_NAME */
+    public const MICROREGION_NAME = 'microregion_name';
+
+    /** @var string MESOREGION_ID */
+    public const MESOREGION_ID = 'mesoregion_id';
+
+    /** @var string MESOREGION_NAME */
+    public const MESOREGION_NAME = 'mesoregion_name';
+
+    /** @var string IMMEDIATE_REGION_ID */
+    public const IMMEDIATE_REGION_ID = 'immediate_region_id';
+
+    /** @var string IMMEDIATE_REGION_NAME */
+    public const IMMEDIATE_REGION_NAME = 'immediate_region_name';
+
+    /** @var string INTERMEDIATE_REGION_ID */
+    public const INTERMEDIATE_REGION_ID = 'intermediate_region_id';
+
+    /** @var string INTERMEDIATE_REGION_NAME */
+    public const INTERMEDIATE_REGION_NAME = 'intermediate_region_name';
+
+    /** @var string STATE_ID */
+    public const STATE_ID = 'state_id';
+
+    /** @var string STATE_CODE */
+    public const STATE_CODE = 'state_code';
+
+    /** @var string STATE_NAME */
+    public const STATE_NAME = 'state_name';
+
+    /** @var string REGION_ID */
+    public const REGION_ID = 'region_id';
+
+    /** @var string REGION_CODE */
+    public const REGION_CODE = 'region_code';
+
+    /** @var string REGION_NAME */
+    public const REGION_NAME = 'region_name';
+
+    /**
+     * Sets county ID
+     *
+     * @param int $countyId
+     * @return self
+     */
+    public function setCountyId(int $countyId): BrazilCountyInterface;
+    /**
+     * Sets county name
+     *
+     * @param string $countyName
+     * @return self
+     */
+    public function setCountyName(string $countyName): BrazilCountyInterface;
+
+    /**
+     * Sets microregion ID
+     *
+     * @param int $microregionId
+     * @return self
+     */
+    public function setMicroregionId(int $microregionId): BrazilCountyInterface;
+
+    /**
+     * Sets microregion name
+     *
+     * @param string $microregionName
+     * @return self
+     */
+    public function setMicroregionName(string $microregionName): BrazilCountyInterface;
+
+    /**
+     * Sets mesoregion ID
+     *
+     * @param int $mesoregionId
+     * @return self
+     */
+    public function setMesoregionId(int $mesoregionId): BrazilCountyInterface;
+
+    /**
+     * Sets mesoregion name
+     *
+     * @param string $mesoregionName
+     * @return self
+     */
+    public function setMesoregionName(string $mesoregionName): BrazilCountyInterface;
+
+    /**
+     * Sets immediate region ID
+     *
+     * @param int $immediateRegionId
+     * @return self
+     */
+    public function setImmediateRegionId(int $immediateRegionId): BrazilCountyInterface;
+
+    /**
+     * Sets immediate region name
+     *
+     * @param string $immediateRegionName
+     * @return self
+     */
+    public function setImmediateRegionName(string $immediateRegionName): BrazilCountyInterface;
+
+    /**
+     * Sets intermediate region ID
+     *
+     * @param int $intermediateRegionId
+     * @return self
+     */
+    public function setIntermediateRegionId(int $intermediateRegionId): BrazilCountyInterface;
+    /**
+     * Sets intermediate region name
+     *
+     * @param string $intermediateRegionName
+     * @return self
+     */
+    public function setIntermediateRegionName(string $intermediateRegionName): BrazilCountyInterface;
+
+    /**
+     * Sets state ID
+     *
+     * @param int $stateId
+     * @return self
+     */
+    public function setStateId(int $stateId): BrazilCountyInterface;
+
+    /**
+     * Sets state code
+     *
+     * @param string $stateCode
+     * @return self
+     */
+    public function setStateCode(string $stateCode): BrazilCountyInterface;
+
+    /**
+     * Sets state name
+     *
+     * @param string $stateName
+     * @return self
+     */
+    public function setStateName(string $stateName): BrazilCountyInterface;
+
+    /**
+     * Sets region ID
+     *
+     * @param int $regionId
+     * @return self
+     */
+    public function setRegionId(int $regionId): BrazilCountyInterface;
+
+    /**
+     * Sets region code
+     *
+     * @param string $regionCode
+     * @return self
+     */
+    public function setRegionCode(string $regionCode): BrazilCountyInterface;
+
+    /**
+     * Sets region name
+     *
+     * @param string $regionName
+     * @return self
+     */
+    public function setRegionName(string $regionName): BrazilCountyInterface;
+
+    /**
+     * Gets entity ID
+     *
+     * @return int
+     */
+    public function getEntityId(): int;
+
+    /**
+     * Gets county ID
+     *
+     * @return int
+     */
+    public function getCountyId(): int;
+
+    /**
+     * Gets county name
+     *
+     * @return string
+     */
+    public function getCountyName(): string;
+
+    /**
+     * Gets microregion ID
+     *
+     * @return int
+     */
+    public function getMicroregionId(): int;
+
+    /**
+     * Gets microregion name
+     *
+     * @return string
+     */
+    public function getMicroregionName(): string;
+
+    /**
+     * Gets mesoregion ID
+     *
+     * @return int
+     */
+    public function getMesoregionId(): int;
+
+    /**
+     * Gets mesoregion name
+     *
+     * @return string
+     */
+    public function getMesoregionName(): string;
+
+    /**
+     * Gets immediate region ID
+     *
+     * @return int
+     */
+    public function getImmediateRegionId(): int;
+
+    /**
+     * Gets immediate region name
+     *
+     * @return string
+     */
+    public function getImmediateRegionName(): string;
+
+    /**
+     * Gets intermediate region ID
+     *
+     * @return int
+     */
+    public function getIntermediateRegionId(): int;
+
+    /**
+     * Gets intermediate region name
+     *
+     * @return string
+     */
+    public function getIntermediateRegionName(): string;
+
+    /**
+     * Gets state ID
+     *
+     * @return int
+     */
+    public function getStateId(): int;
+
+    /**
+     * Gets state code
+     *
+     * @return string
+     */
+    public function getStateCode(): string;
+
+    /**
+     * Gets state name
+     *
+     * @return string
+     */
+    public function getStateName(): string;
+
+    /**
+     * Gets region ID
+     *
+     * @return int
+     */
+    public function getRegionId(): int;
+
+    /**
+     * Gets region code
+     *
+     * @return string
+     */
+    public function getRegionCode(): string;
+
+    /**
+     * Gets region name
+     *
+     * @return string
+     */
+    public function getRegionName(): string;
+}

--- a/Api/Data/BrazilCountyRepositoryInterface.php
+++ b/Api/Data/BrazilCountyRepositoryInterface.php
@@ -10,7 +10,8 @@ use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
- * Interface for brazil_county table repository
+ * Interface BrazilCountyRepositoryInterface
+ * @package TheITNerd\Brasil\Api\Data
  */
 interface BrazilCountyRepositoryInterface
 {

--- a/Api/Data/BrazilCountyRepositoryInterface.php
+++ b/Api/Data/BrazilCountyRepositoryInterface.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Api\Data;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+/**
+ * Interface for brazil_county table repository
+ */
+interface BrazilCountyRepositoryInterface
+{
+    /**
+     * Save Brazil County
+     *
+     * @param BrazilCountyInterface $brazilCounty
+     * @return BrazilCountyInterface
+     * @throws CouldNotSaveException
+     */
+    public function save(BrazilCountyInterface $brazilCounty): BrazilCountyInterface;
+
+    /**
+     * Retrieve Brazil County by entity ID
+     *
+     * @param int $entityId
+     * @return BrazilCountyInterface
+     * @throws NoSuchEntityException
+     */
+    public function getById(int $entityId): BrazilCountyInterface;
+
+    /**
+     * Delete Brazil County
+     *
+     * @param BrazilCountyInterface $brazilCounty
+     * @return bool
+     * @throws CouldNotDeleteException
+     */
+    public function delete(BrazilCountyInterface $brazilCounty): bool;
+
+    /**
+     * Delete Brazil County by entity ID
+     *
+     * @param int $entityId
+     * @return bool
+     * @throws CouldNotDeleteException
+     * @throws NoSuchEntityException
+     */
+    public function deleteById(int $entityId): bool;
+
+    /**
+     * Retrieves Brazil County list matching the search criteria
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return SearchResultsInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface;
+}

--- a/Model/Data/BrazilCounty.php
+++ b/Model/Data/BrazilCounty.php
@@ -8,7 +8,8 @@ use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
 use TheITNerd\Brasil\Model\ResourceModel\BrazilCounty as BrazilCountyResourceModel;
 
 /**
- * Data model for brazil_county table
+ * Class BrazilCounty
+ * @package TheITNerd\Brasil\Model\Data
  */
 class BrazilCounty extends AbstractExtensibleModel implements BrazilCountyInterface
 {

--- a/Model/Data/BrazilCounty.php
+++ b/Model/Data/BrazilCounty.php
@@ -1,0 +1,370 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Model\Data;
+
+use Magento\Framework\Model\AbstractExtensibleModel;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
+use TheITNerd\Brasil\Model\ResourceModel\BrazilCounty as BrazilCountyResourceModel;
+
+/**
+ * Data model for brazil_county table
+ */
+class BrazilCounty extends AbstractExtensibleModel implements BrazilCountyInterface
+{
+    /**
+     * Object initialization
+     *
+     * @return void
+     */
+    protected function _construct(): void
+    {
+        $this->_init(BrazilCountyResourceModel::class);
+    }
+
+    /**
+     * Sets county ID
+     *
+     * @param int $countyId
+     * @return self
+     */
+    public function setCountyId(int $countyId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::COUNTY_ID, $countyId);
+    }
+
+    /**
+     * Sets county name
+     *
+     * @param string $countyName
+     * @return self
+     */
+    public function setCountyName(string $countyName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::COUNTY_NAME, $countyName);
+    }
+
+    /**
+     * Sets microregion ID
+     *
+     * @param int $microregionId
+     * @return self
+     */
+    public function setMicroregionId(int $microregionId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::MICROREGION_ID, $microregionId);
+    }
+
+    /**
+     * Sets microregion name
+     *
+     * @param string $microregionName
+     * @return self
+     */
+    public function setMicroregionName(string $microregionName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::MICROREGION_NAME, $microregionName);
+    }
+
+    /**
+     * Sets mesoregion ID
+     *
+     * @param int $mesoregionId
+     * @return self
+     */
+    public function setMesoregionId(int $mesoregionId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::MESOREGION_ID, $mesoregionId);
+    }
+
+    /**
+     * Sets mesoregion name
+     *
+     * @param string $mesoregionName
+     * @return self
+     */
+    public function setMesoregionName(string $mesoregionName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::MESOREGION_NAME, $mesoregionName);
+    }
+
+    /**
+     * Sets immediate region ID
+     *
+     * @param int $immediateRegionId
+     * @return self
+     */
+    public function setImmediateRegionId(int $immediateRegionId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::IMMEDIATE_REGION_ID, $immediateRegionId);
+    }
+
+    /**
+     * Sets immediate region name
+     *
+     * @param string $immediateRegionName
+     * @return self
+     */
+    public function setImmediateRegionName(string $immediateRegionName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::IMMEDIATE_REGION_NAME, $immediateRegionName);
+    }
+
+    /**
+     * Sets intermediate region ID
+     *
+     * @param int $intermediateRegionId
+     * @return self
+     */
+    public function setIntermediateRegionId(int $intermediateRegionId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::INTERMEDIATE_REGION_ID, $intermediateRegionId);
+    }
+
+    /**
+     * Sets intermediate region name
+     *
+     * @param string $intermediateRegionName
+     * @return self
+     */
+    public function setIntermediateRegionName(string $intermediateRegionName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::INTERMEDIATE_REGION_NAME, $intermediateRegionName);
+    }
+
+    /**
+     * Sets state ID
+     *
+     * @param int $stateId
+     * @return self
+     */
+    public function setStateId(int $stateId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::STATE_ID, $stateId);
+    }
+
+    /**
+     * Sets state code
+     *
+     * @param string $stateCode
+     * @return self
+     */
+    public function setStateCode(string $stateCode): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::STATE_CODE, $stateCode);
+    }
+
+    /**
+     * Sets state name
+     *
+     * @param string $stateName
+     * @return self
+     */
+    public function setStateName(string $stateName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::STATE_NAME, $stateName);
+    }
+
+    /**
+     * Sets region ID
+     *
+     * @param int $regionId
+     * @return self
+     */
+    public function setRegionId(int $regionId): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::REGION_ID, $regionId);
+    }
+
+    /**
+     * Sets region code
+     *
+     * @param string $regionCode
+     * @return self
+     */
+    public function setRegionCode(string $regionCode): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::REGION_CODE, $regionCode);
+    }
+
+    /**
+     * Sets region name
+     *
+     * @param string $regionName
+     * @return self
+     */
+    public function setRegionName(string $regionName): BrazilCountyInterface
+    {
+        return $this->setData(BrazilCountyInterface::REGION_NAME, $regionName);
+    }
+
+    /**
+     * Gets entity ID
+     *
+     * @return int
+     */
+    public function getEntityId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::ENTITY_ID);
+    }
+
+    /**
+     * Gets county ID
+     *
+     * @return int
+     */
+    public function getCountyId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::COUNTY_ID);
+    }
+
+    /**
+     * Gets county name
+     *
+     * @return string
+     */
+    public function getCountyName(): string
+    {
+        return $this->getData(BrazilCountyInterface::COUNTY_NAME);
+    }
+
+    /**
+     * Gets microregion ID
+     *
+     * @return int
+     */
+    public function getMicroregionId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::MICROREGION_ID);
+    }
+
+    /**
+     * Gets microregion name
+     *
+     * @return string
+     */
+    public function getMicroregionName(): string
+    {
+        return $this->getData(BrazilCountyInterface::MICROREGION_NAME);
+    }
+
+    /**
+     * Gets mesoregion ID
+     *
+     * @return int
+     */
+    public function getMesoregionId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::MESOREGION_ID);
+    }
+
+    /**
+     * Gets mesoregion name
+     *
+     * @return string
+     */
+    public function getMesoregionName(): string
+    {
+        return $this->getData(BrazilCountyInterface::MESOREGION_NAME);
+    }
+
+    /**
+     * Gets immediate region ID
+     *
+     * @return int
+     */
+    public function getImmediateRegionId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::IMMEDIATE_REGION_ID);
+    }
+
+    /**
+     * Gets immediate region name
+     *
+     * @return string
+     */
+    public function getImmediateRegionName(): string
+    {
+        return $this->getData(BrazilCountyInterface::IMMEDIATE_REGION_NAME);
+    }
+
+    /**
+     * Gets intermediate region ID
+     *
+     * @return int
+     */
+    public function getIntermediateRegionId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::INTERMEDIATE_REGION_ID);
+    }
+
+    /**
+     * Gets intermediate region name
+     *
+     * @return string
+     */
+    public function getIntermediateRegionName(): string
+    {
+        return $this->getData(BrazilCountyInterface::INTERMEDIATE_REGION_NAME);
+    }
+
+    /**
+     * Gets state ID
+     *
+     * @return int
+     */
+    public function getStateId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::STATE_ID);
+    }
+
+    /**
+     * Gets state code
+     *
+     * @return string
+     */
+    public function getStateCode(): string
+    {
+        return $this->getData(BrazilCountyInterface::STATE_CODE);
+    }
+
+    /**
+     * Gets state name
+     *
+     * @return string
+     */
+    public function getStateName(): string
+    {
+        return $this->getData(BrazilCountyInterface::STATE_NAME);
+    }
+
+    /**
+     * Gets region ID
+     *
+     * @return int
+     */
+    public function getRegionId(): int
+    {
+        return (int) $this->getData(BrazilCountyInterface::REGION_ID);
+    }
+
+    /**
+     * Gets region code
+     *
+     * @return string
+     */
+    public function getRegionCode(): string
+    {
+        return $this->getData(BrazilCountyInterface::REGION_CODE);
+    }
+
+    /**
+     * Gets region name
+     *
+     * @return string
+     */
+    public function getRegionName(): string
+    {
+        return $this->getData(BrazilCountyInterface::REGION_NAME);
+    }
+}

--- a/Model/Data/BrazilCountyRepository.php
+++ b/Model/Data/BrazilCountyRepository.php
@@ -19,6 +19,7 @@ use Magento\Framework\Api\SearchResultsInterface;
 
 /**
  * Class BrazilCountyRepository
+ * @package TheITNerd\Brasil\Model\Data
  */
 class BrazilCountyRepository implements BrazilCountyRepositoryInterface
 {
@@ -30,10 +31,10 @@ class BrazilCountyRepository implements BrazilCountyRepositoryInterface
      * @param SearchResultsInterfaceFactory $searchResultsFactory
      */
     public function __construct(
-        private readonly BrazilCountyResource $resource,
-        private readonly BrazilCountyInterfaceFactory $brazilCountyFactory,
+        private readonly BrazilCountyResource          $resource,
+        private readonly BrazilCountyInterfaceFactory  $brazilCountyFactory,
         private readonly BrazilCountyCollectionFactory $brazilCountyCollectionFactory,
-        private readonly CollectionProcessorInterface $collectionProcessor,
+        private readonly CollectionProcessorInterface  $collectionProcessor,
         private readonly SearchResultsInterfaceFactory $searchResultsFactory
     ) {
     }

--- a/Model/Data/BrazilCountyRepository.php
+++ b/Model/Data/BrazilCountyRepository.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Model\Data;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterfaceFactory;
+use TheITNerd\Brasil\Model\ResourceModel\BrazilCounty as BrazilCountyResource;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use TheITNerd\Brasil\Model\ResourceModel\BrazilCounty\CollectionFactory as BrazilCountyCollectionFactory;
+use TheITNerd\Brasil\Model\ResourceModel\BrazilCounty\Collection as BrazilCountyCollection;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchResultsInterfaceFactory;
+use Magento\Framework\Api\SearchResultsInterface;
+
+/**
+ * Class BrazilCountyRepository
+ */
+class BrazilCountyRepository implements BrazilCountyRepositoryInterface
+{
+    /**
+     * @param BrazilCountyResource $resource
+     * @param BrazilCountyInterfaceFactory $brazilCountyFactory
+     * @param BrazilCountyCollectionFactory $brazilCountyCollectionFactory
+     * @param CollectionProcessorInterface $collectionProcessor
+     * @param SearchResultsInterfaceFactory $searchResultsFactory
+     */
+    public function __construct(
+        private readonly BrazilCountyResource $resource,
+        private readonly BrazilCountyInterfaceFactory $brazilCountyFactory,
+        private readonly BrazilCountyCollectionFactory $brazilCountyCollectionFactory,
+        private readonly CollectionProcessorInterface $collectionProcessor,
+        private readonly SearchResultsInterfaceFactory $searchResultsFactory
+    ) {
+    }
+
+    /**
+     * Save Brazil County
+     *
+     * @param BrazilCountyInterface $brazilCounty
+     * @return BrazilCountyInterface
+     * @throws CouldNotSaveException
+     */
+    public function save(BrazilCountyInterface $brazilCounty): BrazilCountyInterface
+    {
+        try {
+            $this->resource->save($brazilCounty);
+        } catch (\Exception $exception) {
+            throw new CouldNotSaveException(__(
+                'Could not save the Brazil County: %1',
+                $exception->getMessage()
+            ));
+        }
+        return $brazilCounty;
+    }
+
+    /**
+     * Retrieve Brazil County by entity ID
+     *
+     * @param int $entityId
+     * @return BrazilCountyInterface
+     * @throws NoSuchEntityException
+     */
+    public function getById(int $entityId): BrazilCountyInterface
+    {
+        $brazilCounty = $this->brazilCountyFactory->create();
+        $this->resource->load($brazilCounty, $entityId);
+        if (!$brazilCounty->getId()) {
+            throw new NoSuchEntityException(__('Brazil County with ID "%1" does not exist.', $entityId));
+        }
+        return $brazilCounty;
+    }
+
+    /**
+     * Delete Brazil County
+     *
+     * @param BrazilCountyInterface $brazilCounty
+     * @return bool
+     * @throws CouldNotDeleteException
+     */
+    public function delete(BrazilCountyInterface $brazilCounty): bool
+    {
+        try {
+            $this->resource->delete($brazilCounty);
+        } catch (\Exception $exception) {
+            throw new CouldNotDeleteException(__(
+                'Could not delete the Brazil County: %1',
+                $exception->getMessage()
+            ));
+        }
+        return true;
+    }
+
+    /**
+     * Delete Brazil County by entity ID
+     *
+     * @param int $entityId
+     * @return bool
+     * @throws CouldNotDeleteException
+     * @throws NoSuchEntityException
+     */
+    public function deleteById(int $entityId): bool
+    {
+        return $this->delete($this->getById($entityId));
+    }
+
+    /**
+     * Retrieves Brazil County list matching the search criteria
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return SearchResultsInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface
+    {
+        /** @var BrazilCountyCollection $collection */
+        $collection = $this->brazilCountyCollectionFactory->create();
+
+        $this->collectionProcessor->process($searchCriteria, $collection);
+        $collection->load();
+
+        /** @var SearchResultsInterface $searchResults */
+        $searchResults = $this->searchResultsFactory->create()
+            ->setSearchCriteria($searchCriteria)
+            ->setItems($collection->getItems())
+            ->setTotalCount($collection->getSize());
+
+        return $searchResults;
+    }
+}

--- a/Model/Resolver/BrazilCounties.php
+++ b/Model/Resolver/BrazilCounties.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Model\Resolver;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+
+/**
+ * Resolver to return county information based on filters
+ */
+class BrazilCounties implements ResolverInterface
+{
+    /**
+     * @param BrazilCountyRepositoryInterface $brazilCountyRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     */
+    public function __construct(
+        private readonly BrazilCountyRepositoryInterface $brazilCountyRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+    }
+
+    /**
+     * Fetches the data from persistence models and format it according to the GraphQL schema.
+     *
+     * @param Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return array
+     */
+    public function resolve(
+        Field $field,
+              $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ): array {
+        $filters = $args['filters'] ?? [];
+
+        foreach ($filters as $filter) {
+            foreach ($filter['filter'] as $condition => $value) {
+                $this->searchCriteriaBuilder->addFilter($filter['field'], $value, $condition);
+            }
+        }
+
+        $searchCriteria = $this->searchCriteriaBuilder->create();
+
+        return $this->brazilCountyRepository->getList($searchCriteria)->getItems();
+    }
+}

--- a/Model/Resolver/BrazilCounties.php
+++ b/Model/Resolver/BrazilCounties.php
@@ -12,7 +12,8 @@ use TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 
 /**
- * Resolver to return county information based on filters
+ * Class BrazilCounties
+ * @package TheITNerd\Brasil\Model\Resolver
  */
 class BrazilCounties implements ResolverInterface
 {
@@ -22,7 +23,7 @@ class BrazilCounties implements ResolverInterface
      */
     public function __construct(
         private readonly BrazilCountyRepositoryInterface $brazilCountyRepository,
-        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+        private readonly SearchCriteriaBuilder           $searchCriteriaBuilder
     ) {
     }
 

--- a/Model/ResourceModel/BrazilCounty.php
+++ b/Model/ResourceModel/BrazilCounty.php
@@ -7,7 +7,8 @@ use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
 
 /**
- * Resource model for brazil_county table
+ * Class BrazilCounty
+ * @package TheITNerd\Brasil\Model\ResourceModel
  */
 class BrazilCounty extends AbstractDb
 {

--- a/Model/ResourceModel/BrazilCounty.php
+++ b/Model/ResourceModel/BrazilCounty.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
+
+/**
+ * Resource model for brazil_county table
+ */
+class BrazilCounty extends AbstractDb
+{
+    /**
+     * Resource initialization
+     *
+     * @return void
+     */
+    protected function _construct(): void
+    {
+        $this->_init(BrazilCountyInterface::TABLE, BrazilCountyInterface::ENTITY_ID);
+    }
+}

--- a/Model/ResourceModel/BrazilCounty/Collection.php
+++ b/Model/ResourceModel/BrazilCounty/Collection.php
@@ -9,7 +9,8 @@ use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
 use TheITNerd\Brasil\Model\Data\BrazilCounty;
 
 /**
- * Collection class for brazil_county table
+ * Class Collection
+ * @package TheITNerd\Brasil\Model\ResourceModel\BrazilCounty
  */
 class Collection extends AbstractCollection
 {

--- a/Model/ResourceModel/BrazilCounty/Collection.php
+++ b/Model/ResourceModel/BrazilCounty/Collection.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Model\ResourceModel\BrazilCounty;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use TheITNerd\Brasil\Model\ResourceModel\BrazilCounty as BrazilCountyResourceModel;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
+use TheITNerd\Brasil\Model\Data\BrazilCounty;
+
+/**
+ * Collection class for brazil_county table
+ */
+class Collection extends AbstractCollection
+{
+    /**
+     * @var string
+     */
+    protected $_idFieldName = BrazilCountyInterface::ENTITY_ID;
+
+    /**
+     * Define resource model
+     *
+     * @return void
+     */
+    protected function _construct(): void
+    {
+        $this->_init(BrazilCounty::class, BrazilCountyResourceModel::class);
+    }
+}

--- a/Setup/Patch/Data/PopulateBrazilCountyTable.php
+++ b/Setup/Patch/Data/PopulateBrazilCountyTable.php
@@ -12,7 +12,8 @@ use TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface;
 use TheITNerd\Brasil\Api\Data\BrazilCountyInterfaceFactory;
 
 /**
- * Data patch to insert data in brazil_county table
+ * Class PopulateBrazilCountyTable
+ * @package TheITNerd\Brasil\Setup\Patch\Data
  */
 class PopulateBrazilCountyTable implements DataPatchInterface
 {
@@ -23,10 +24,10 @@ class PopulateBrazilCountyTable implements DataPatchInterface
      * @param BrazilCountyInterfaceFactory $brazilCountyFactory
      */
     public function __construct(
-        private readonly ModuleDataSetupInterface $moduleDataSetup,
-        private readonly Curl $curl,
+        private readonly ModuleDataSetupInterface        $moduleDataSetup,
+        private readonly Curl                            $curl,
         private readonly BrazilCountyRepositoryInterface $brazilCountyRepository,
-        private readonly BrazilCountyInterfaceFactory $brazilCountyFactory
+        private readonly BrazilCountyInterfaceFactory    $brazilCountyFactory
     ) {
     }
 

--- a/Setup/Patch/Data/PopulateBrazilCountyTable.php
+++ b/Setup/Patch/Data/PopulateBrazilCountyTable.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+namespace TheITNerd\Brasil\Setup\Patch\Data;
+
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterface;
+use TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface;
+use TheITNerd\Brasil\Api\Data\BrazilCountyInterfaceFactory;
+
+/**
+ * Data patch to insert data in brazil_county table
+ */
+class PopulateBrazilCountyTable implements DataPatchInterface
+{
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param Curl $curl
+     * @param BrazilCountyRepositoryInterface $brazilCountyRepository
+     * @param BrazilCountyInterfaceFactory $brazilCountyFactory
+     */
+    public function __construct(
+        private readonly ModuleDataSetupInterface $moduleDataSetup,
+        private readonly Curl $curl,
+        private readonly BrazilCountyRepositoryInterface $brazilCountyRepository,
+        private readonly BrazilCountyInterfaceFactory $brazilCountyFactory
+    ) {
+    }
+
+    /**
+     * Run code inside patch
+     * If code fails, patch must be reverted, in case when we are speaking about schema - then under revert
+     * means run PatchInterface::revert()
+     *
+     * If we speak about data, under revert means: $transaction->rollback()
+     *
+     * @return $this
+     * @throws CouldNotSaveException
+     */
+    public function apply(): self
+    {
+        $this->moduleDataSetup->startSetup();
+
+        $url = 'https://servicodados.ibge.gov.br/api/v1/localidades/municipios?view=nivelado';
+
+        $this->curl->get($url);
+        $response = $this->curl->getBody();
+
+        $data = json_decode($response, true);
+
+        $batchSize = 1000;
+        $batches = array_chunk($data, $batchSize);
+
+        foreach ($batches as $batchNum => $batch) {
+            $this->moduleDataSetup->getConnection()->beginTransaction();
+            try {
+                foreach ($batch as $county) {
+                    /** @var $brazilCounty BrazilCountyInterface */
+                    $brazilCounty = $this->brazilCountyFactory->create();
+
+                    $brazilCounty->setCountyId($county['municipio-id'])
+                        ->setCountyName($county['municipio-nome'])
+                        ->setMicroregionId($county['microrregiao-id'])
+                        ->setMicroregionName($county['microrregiao-nome'])
+                        ->setMesoregionId($county['mesorregiao-id'])
+                        ->setMesoregionName($county['mesorregiao-nome'])
+                        ->setImmediateRegionId($county['regiao-imediata-id'])
+                        ->setImmediateRegionName($county['regiao-imediata-nome'])
+                        ->setIntermediateRegionId($county['regiao-intermediaria-id'])
+                        ->setIntermediateRegionName($county['regiao-intermediaria-nome'])
+                        ->setStateId($county['UF-id'])
+                        ->setStateCode($county['UF-sigla'])
+                        ->setStateName($county['UF-nome'])
+                        ->setRegionId($county['regiao-id'])
+                        ->setRegionCode($county['regiao-sigla'])
+                        ->setRegionName($county['regiao-nome']);
+
+                    $this->brazilCountyRepository->save($brazilCounty);
+                }
+                $this->moduleDataSetup->getConnection()->commit();
+            } catch (\Exception $e) {
+                $this->moduleDataSetup->getConnection()->rollBack();
+                throw new CouldNotSaveException(__(
+                    'An error occurred while saving batch number %1.',
+                    $batchNum
+                ), $e);
+            }
+        }
+
+        $this->moduleDataSetup->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * Get array of patches that have to be executed prior to this.
+     *
+     * Example of implementation:
+     *
+     * [
+     *      \Vendor_Name\Module_Name\Setup\Patch\Patch1::class,
+     *      \Vendor_Name\Module_Name\Setup\Patch\Patch2::class
+     * ]
+     *
+     * @return string[]
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get aliases (previous names) for the patch.
+     *
+     * @return string[]
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Data/PopulateBrazilCountyTable.php
+++ b/Setup/Patch/Data/PopulateBrazilCountyTable.php
@@ -51,43 +51,28 @@ class PopulateBrazilCountyTable implements DataPatchInterface
 
         $data = json_decode($response, true);
 
-        $batchSize = 1000;
-        $batches = array_chunk($data, $batchSize);
+        foreach ($data as $county) {
+            /** @var $brazilCounty BrazilCountyInterface */
+            $brazilCounty = $this->brazilCountyFactory->create();
 
-        foreach ($batches as $batchNum => $batch) {
-            $this->moduleDataSetup->getConnection()->beginTransaction();
-            try {
-                foreach ($batch as $county) {
-                    /** @var $brazilCounty BrazilCountyInterface */
-                    $brazilCounty = $this->brazilCountyFactory->create();
+            $brazilCounty->setCountyId($county['municipio-id'])
+                ->setCountyName($county['municipio-nome'])
+                ->setMicroregionId($county['microrregiao-id'])
+                ->setMicroregionName($county['microrregiao-nome'])
+                ->setMesoregionId($county['mesorregiao-id'])
+                ->setMesoregionName($county['mesorregiao-nome'])
+                ->setImmediateRegionId($county['regiao-imediata-id'])
+                ->setImmediateRegionName($county['regiao-imediata-nome'])
+                ->setIntermediateRegionId($county['regiao-intermediaria-id'])
+                ->setIntermediateRegionName($county['regiao-intermediaria-nome'])
+                ->setStateId($county['UF-id'])
+                ->setStateCode($county['UF-sigla'])
+                ->setStateName($county['UF-nome'])
+                ->setRegionId($county['regiao-id'])
+                ->setRegionCode($county['regiao-sigla'])
+                ->setRegionName($county['regiao-nome']);
 
-                    $brazilCounty->setCountyId($county['municipio-id'])
-                        ->setCountyName($county['municipio-nome'])
-                        ->setMicroregionId($county['microrregiao-id'])
-                        ->setMicroregionName($county['microrregiao-nome'])
-                        ->setMesoregionId($county['mesorregiao-id'])
-                        ->setMesoregionName($county['mesorregiao-nome'])
-                        ->setImmediateRegionId($county['regiao-imediata-id'])
-                        ->setImmediateRegionName($county['regiao-imediata-nome'])
-                        ->setIntermediateRegionId($county['regiao-intermediaria-id'])
-                        ->setIntermediateRegionName($county['regiao-intermediaria-nome'])
-                        ->setStateId($county['UF-id'])
-                        ->setStateCode($county['UF-sigla'])
-                        ->setStateName($county['UF-nome'])
-                        ->setRegionId($county['regiao-id'])
-                        ->setRegionCode($county['regiao-sigla'])
-                        ->setRegionName($county['regiao-nome']);
-
-                    $this->brazilCountyRepository->save($brazilCounty);
-                }
-                $this->moduleDataSetup->getConnection()->commit();
-            } catch (\Exception $e) {
-                $this->moduleDataSetup->getConnection()->rollBack();
-                throw new CouldNotSaveException(__(
-                    'An error occurred while saving batch number %1.',
-                    $batchNum
-                ), $e);
-            }
+            $this->brazilCountyRepository->save($brazilCounty);
         }
 
         $this->moduleDataSetup->endSetup();

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="brazil_county" resource="default" engine="innodb" comment="Counties table with IBGE data">
+        <column xsi:type="int" name="entity_id" padding="10" unsigned="true" nullable="false" comment="Entity ID" identity="true"/>
+        <column xsi:type="int" name="county_id" nullable="false" comment="County id"/>
+        <column xsi:type="varchar" name="county_name" nullable="false" length="255" comment="County name"/>
+        <column xsi:type="int" name="microregion_id" nullable="false" comment="Microregion id"/>
+        <column xsi:type="varchar" name="microregion_name" nullable="false" length="255" comment="Microregion name"/>
+        <column xsi:type="int" name="mesoregion_id" nullable="false" comment="Mesoregion id"/>
+        <column xsi:type="varchar" name="mesoregion_name" nullable="false" length="255" comment="Mesoregion name"/>
+        <column xsi:type="int" name="immediate_region_id" nullable="false" comment="Immediate Region ID"/>
+        <column xsi:type="varchar" name="immediate_region_name" nullable="false" length="255" comment="Immediate Region Name"/>
+        <column xsi:type="int" name="intermediate_region_id" nullable="false" comment="Intermediate Region ID"/>
+        <column xsi:type="varchar" name="intermediate_region_name" nullable="false" length="255" comment="Intermediate Region Name"/>
+        <column xsi:type="int" name="state_id" nullable="false" comment="State ID"/>
+        <column xsi:type="varchar" name="state_code" nullable="false" length="2" comment="State Code (UF)"/>
+        <column xsi:type="varchar" name="state_name" nullable="false" length="255" comment="State Name"/>
+        <column xsi:type="int" name="region_id" nullable="false" comment="Region ID"/>
+        <column xsi:type="varchar" name="region_code" nullable="false" length="2" comment="Region Code"/>
+        <column xsi:type="varchar" name="region_name" nullable="false" length="255" comment="Region Name"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="entity_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="BRAZIL_COUNTY_UNIQUE_COUNTY_ID">
+            <column name="county_id"/>
+        </constraint>
+    </table>
+</schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
+    <!-- START INTERFACE PREFERENCE DECLARATION -->
+    <preference for="TheITNerd\Brasil\Api\Data\BrazilCountyInterface" type="TheITNerd\Brasil\Model\Data\BrazilCounty"/>
+    <preference for="TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface" type="TheITNerd\Brasil\Model\Data\BrazilCountyRepository"/>
+    <!-- END INTERFACE PREFERENCE DECLARATION -->
+
     <!-- START CHECKOUT MODIFICATIONS -->
     <type name="Magento\Checkout\Block\Cart\LayoutProcessor">
         <plugin name="change_checkout_cart_shipping_estimate_form" type="TheITNerd\Brasil\Plugin\Magento\Checkout\Block\Cart\LayoutProcessorPlugin"/>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
-    <!-- START INTERFACE PREFERENCE DECLARATION -->
+    <!-- START BRAZIL COUNTIES DATABASE TABLE CLASSES -->
     <preference for="TheITNerd\Brasil\Api\Data\BrazilCountyInterface" type="TheITNerd\Brasil\Model\Data\BrazilCounty"/>
     <preference for="TheITNerd\Brasil\Api\Data\BrazilCountyRepositoryInterface" type="TheITNerd\Brasil\Model\Data\BrazilCountyRepository"/>
-    <!-- END INTERFACE PREFERENCE DECLARATION -->
+    <!-- END BRAZIL COUNTIES DATABASE TABLE CLASSES -->
 
     <!-- START CHECKOUT MODIFICATIONS -->
     <type name="Magento\Checkout\Block\Cart\LayoutProcessor">

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,46 @@
+type BrazilCounty {
+    entity_id: Int
+    county_id: Int
+    county_name: String
+    microregion_id: Int
+    microregion_name: String
+    mesoregion_id: Int
+    mesoregion_name: String
+    immediate_region_id: Int
+    immediate_region_name: String
+    intermediate_region_id: Int
+    intermediate_region_name: String
+    state_id: Int
+    state_code: String
+    state_name: String
+    region_id: Int
+    region_code: String
+    region_name: String
+}
+
+input BrazilCountyFilterInput {
+    field: String! @doc(description:"Field to be filtered")
+    filter: FilterTypeInput! @doc(description:"Filter declaration")
+}
+
+type Query {
+    brazilCounties(filters: [BrazilCountyFilterInput]): [BrazilCounty]
+        @resolver(class: "TheITNerd\\Brasil\\Model\\Resolver\\BrazilCounties")
+        @doc(description: "Resolver to return county information based on filters")
+}
+# Example of query
+#query{
+#    brazilCounties(
+#        filters: [
+#            {
+#                field: "county_name"
+#                filter: {
+#                    eq: "Itupeva"
+#                }
+#            }
+#        ]
+#    ) {
+#        county_id
+#        ...
+#    }
+#}


### PR DESCRIPTION
Pull request que adiciona tabela brazil_county para armazenar informações de todos os municipios do brasil, ao rodar setup upgrade, o data patch vai fazer uma requisição para o IBGE e vai preencher todas as cidades na tabela, após isso pode ser utilizada a query brazilCounties para qualquer que seja o proposito, escolhendo as informações que devem ser retornadas e podendo filtrar por qualquer campo e com qualquer condição nativa do magento.

A ideia inicial é utilizar a tabela para melhor a experiencia do usuario principalmente ao cadastrar endereços, futuramente sendo desenvolvido no front um select que traz as cidades de acordo com o estado selecionado, até evitando entradas incorretas.

Ainda pretendo adicionar testes unitários principalmente a Repository e a Resolver, qualquer sugestão ou dúvida estou a disposição.

E também vejam se faz sentido incluir uma funcionalidade um pouco mais especifica como essa no modulo, se for o caso posso fazer um modulo separado pra isso.

Ah e só pra constar pelo menos no meu ambiente o data patch demorou por volta de 10 segundos pra rodar e preencher a tabela.