### PR TITLE
:sparkles: [EZ-90] Permite apenas CNPJ no formulário de criação de em…

### DIFF
--- a/view/frontend/templates/company/account/create/masks.phtml
+++ b/view/frontend/templates/company/account/create/masks.phtml
@@ -4,16 +4,16 @@
 $regionProvider = $block->getRegionProvider();
 ?>
 <script type="text/x-magento-init">
-{
-    "#telephone": {
-        "TheITNerd_Core/js/inputMask": {
-            "mask": "(00) 0000-00009"
-        }
-    },
-    "#postcode": {
-        "TheITNerd_Core/js/postcode": {
-            "mask": "00000-000",
-            "regionJson": <?= $regionProvider->getRegionJson() ?>,
+    {
+        "#telephone": {
+            "TheITNerd_Core/js/inputMask": {
+                "mask": "(00) 0000-00009"
+            }
+        },
+        "#postcode": {
+            "TheITNerd_Core/js/postcode": {
+                "mask": "00000-000",
+                "regionJson": <?= $regionProvider->getRegionJson() ?>,
             "addressFields": {
                 "street": "[name='company[street][0]']",
                 "neighborhood": "[name='company[street][3]']",
@@ -26,11 +26,9 @@ $regionProvider = $block->getRegionProvider();
     },
     "#vat_tax_id": {
         "TheITNerd_Brasil/js/cpfCnpjField": {
-            "mask": "00000-000"
+            "mask": "00000-000",
+            "cpf": false
         }
-    },
-    "#vat_tax_id": {
-        "TheITNerd_Brasil/js/cpfCnpjField": {}
     }
 }
 </script>

--- a/view/frontend/web/js/cpfCnpjField.js
+++ b/view/frontend/web/js/cpfCnpjField.js
@@ -25,6 +25,7 @@ define([
         },
 
         initOptions: function() {
+
             this.options.uniqueID = Math.random().toString(36).substring(2, 9);
             this.options.parentElement = this.element.closest(this.options.parent);
             this.options.labelElement = this.options.parentElement.find(this.options.label);
@@ -33,6 +34,11 @@ define([
         },
 
         createCnpjCheckbox: function() {
+
+            if (!this.options.cpf || !this.options.cnpj) {
+                return this;
+            }
+
             let html = '<div class="cnpj-checkbox"><label><input type="checkbox" id="' + this.options.uniqueID + '"/> ' + $.mage.__('Usar CNPJ') + '</label></div>';
             this.options.parentElement.append(html);
 
@@ -45,6 +51,9 @@ define([
         },
 
         isCNPJ: function() {
+            if (!this.options.cpf && this.options.cnpj) {
+                return true
+            }
             return $('#'+this.options.uniqueID).is(':checked');
         },
 
@@ -61,15 +70,16 @@ define([
                 this.element.data('theitnerdInputmask').remove();
             }
 
-            if(this.isCNPJ()) {
+            if(this.isCNPJ() && this.options.cnpj) {
                 this.element.inputmask({mask: this.options.masks.cnpj});
                 this.element.removeClass('validate-cpf');
                 this.element.addClass('validate-cnpj');
-            } else {
+            } else if (this.options.cpf) {
                 this.element.inputmask({mask: this.options.masks.cpf});
                 this.element.removeClass('validate-cnpj');
                 this.element.addClass('validate-cpf');
             }
+
 
             this.changeLabel();
         }


### PR DESCRIPTION
Permite escolher variações de tipos de taxvat entre CPF e CNPJ.
Permite configurar as opções do formulário das seguintes formas:
* CPF e CNPJ (padrão);
* Somente CPF;
* Somente CNPJ;